### PR TITLE
Better client packages preservation

### DIFF
--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -68,6 +68,7 @@ function cleanUp() {
 		'maps/**/*',
 		'plugins/**/*',
 		'client_packages/game_resources/**/*',
+		'client_packages/package2/**/*',
 		'pnpm-lock.yaml',
 		'package-lock.json',
 		'yarn.lock'

--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -67,7 +67,7 @@ function cleanUp() {
 		'dotnet/**/*',
 		'maps/**/*',
 		'plugins/**/*',
-		'client_packages/game_resources/dlcpacks/**/*',
+		'client_packages/game_resources/**/*',
 		'pnpm-lock.yaml',
 		'package-lock.json',
 		'yarn.lock'


### PR DESCRIPTION
I noticed that rollup script does not preserve whole **game_resources** and **package2** folders. Can be a bit annoying as it does not delete but clears the folders so can be harder to notice what happened. 
I think it's better to just ignore them both from start.